### PR TITLE
Ensure QR is ready before capture

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -654,7 +654,7 @@ $(document).ready(function() {
         doGenerateTicket();
     });
 
-    $("#confirmarTicket").click(function() {
+    $("#confirmarTicket").click(async function() {
         const $confirmButton = $(this);
         $confirmButton.prop("disabled", true); 
         $("#editButton").addClass("d-none");
@@ -695,28 +695,9 @@ $(document).ready(function() {
         }
         
         // Esperar a que el QR termine de renderizarse antes de capturar
-        const qrContainer = document.getElementById("qrcode");
-        const qrImg = qrContainer ? qrContainer.querySelector("img") : null;
-        const qrCanvas = qrContainer ? qrContainer.querySelector("canvas") : null;
-
-        const waitForQR = new Promise(resolve => {
-            if (qrImg) {
-                if (qrImg.complete) {
-                    resolve();
-                } else {
-                    qrImg.addEventListener("load", () => resolve(), { once: true });
-                }
-            } else if (qrCanvas) {
-                // El canvas se dibuja sin evento 'load'; esperar al siguiente frame
-                requestAnimationFrame(() => resolve());
-            } else {
-                resolve();
-            }
-        });
-
-        waitForQR.then(() => {
-            const jugadasCount = $("#ticketJugadas tr").length;
-            console.log(`Generando ticket para DESCARGA con ${jugadasCount} jugadas`);
+        await waitForQrReady();
+        const jugadasCount = $("#ticketJugadas tr").length;
+        console.log(`Generando ticket para DESCARGA con ${jugadasCount} jugadas`);
             
             // SOLUCIÓN MEJORADA: Pre-ajustar altura con valores más agresivos
             const preTicket = document.getElementById("preTicket");
@@ -918,7 +899,6 @@ $(document).ready(function() {
                 console.error("Error generando imagen de descarga:", error);
                 alert("Error generating ticket for download: " + error.message);
             });
-        }); // Esperar a la carga del QR antes de capturar
     });
     
     $("#editButton").click(function(){


### PR DESCRIPTION
## Summary
- call `waitForQrReady` in the Confirm Ticket flow instead of a custom promise
- wait for QR in share flow before capturing (already present)

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685248f65edc83248579531e9da50fa7