### PR TITLE
Adjust ticket render scale and improve mobile font readability

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -750,7 +750,7 @@ $(document).ready(function() {
             
             // CONFIGURACIÓN ESTABLE PARA DESCARGA (después de pre-ajustes)
             html2canvas(document.getElementById("preTicket"), {
-                scale: 4, // Escala alta pero estable
+                scale: 5, // Escala alta para mayor claridad
                 useCORS: true,
                 allowTaint: true,
                 backgroundColor: '#ffffff',
@@ -959,7 +959,7 @@ $(document).ready(function() {
                 
                 // CONFIGURACIÓN MÁS CONSERVADORA para compartir (evitar imagen en blanco)
                 const canvas = await html2canvas(document.getElementById("preTicket"), {
-                    scale: 3, // Escala moderada para evitar problemas de memoria
+                    scale: 5, // Escala elevada para mejor detalle
                     useCORS: true,
                     allowTaint: true,
                     backgroundColor: '#ffffff',

--- a/public/styles.css
+++ b/public/styles.css
@@ -1677,18 +1677,18 @@ body.light-mode .flatpickr-day.disabled {
   }
   
   #preTicket .table {
-    font-size: 0.65rem !important;
+    font-size: 0.85rem !important;
     margin: 8px 0 !important;
   }
-  
+
   #preTicket .table th {
     padding: 2px 1px !important;
-    font-size: 0.6rem !important;
+    font-size: 0.8rem !important;
   }
-  
+
   #preTicket .table td {
     padding: 2px 1px !important;
-    font-size: 0.65rem !important;
+    font-size: 0.8rem !important;
   }
   
   #preTicket .total-section {


### PR DESCRIPTION
## Summary
- increase `html2canvas` scale in download and share flows for sharper images
- enlarge mobile table fonts for easier reading

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685248f905f48324965468938044ae95