### PR TITLE
Ensure QR rendering waits for positive dimensions

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -1359,7 +1359,7 @@ function debugQRCapture() {
     }
 }
 
-async function waitForQrReady(timeout = 2000) {
+async function waitForQrReady(timeout = 4000) {
     const qr = document.getElementById('qrcode');
     if (!qr) return;
 
@@ -1368,8 +1368,13 @@ async function waitForQrReady(timeout = 2000) {
         (function check() {
             const canvas = qr.querySelector('canvas');
             const img = qr.querySelector('img');
-            if ((canvas && canvas.offsetHeight > 0) ||
-                (img && img.complete && img.naturalHeight > 0)) {
+            const canvasReady = canvas &&
+                (canvas.naturalWidth > 0 || canvas.width > 0) &&
+                (canvas.naturalHeight > 0 || canvas.height > 0);
+            const imgReady = img && img.complete &&
+                img.naturalWidth > 0 && img.naturalHeight > 0;
+
+            if (canvasReady || imgReady) {
                 resolve();
             } else if (Date.now() - start > timeout) {
                 resolve();


### PR DESCRIPTION
## Summary
- extend `waitForQrReady` default timeout to 4000 ms
- require positive `naturalWidth` and `naturalHeight` for QR canvas or image before resolving

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run typecheck` *(fails: module not found in BetTable.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68525922006883248275c4c8029359a8