### PR TITLE
Increase html2canvas scale for crisp tickets

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -738,7 +738,7 @@ $(document).ready(function() {
             
             // CONFIGURACIÓN ESTABLE PARA DESCARGA (después de pre-ajustes)
             html2canvas(document.getElementById("preTicket"), {
-                scale: 5, // Escala alta para mayor claridad
+                scale: 6, // Escala más alta para mayor claridad
                 useCORS: true,
                 allowTaint: true,
                 backgroundColor: '#ffffff',
@@ -964,7 +964,7 @@ $(document).ready(function() {
                 
                 // CONFIGURACIÓN MÁS CONSERVADORA para compartir (evitar imagen en blanco)
                 const canvas = await html2canvas(document.getElementById("preTicket"), {
-                    scale: 5, // Escala elevada para mejor detalle
+                    scale: 6, // Escala aún más elevada para mejor detalle
                     useCORS: true,
                     allowTaint: true,
                     backgroundColor: '#ffffff',


### PR DESCRIPTION
## Summary
- bump html2canvas scale to 6 in download/share flows

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: Module '@/app/page' has no exported member 'Bet')*

------
https://chatgpt.com/codex/tasks/task_e_6852592c4f648324a835c77db9007114