### PR TITLE
Add CSV export button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -290,6 +290,13 @@
                     <span class="action-button-name">Reset</span>
                   </button>
                 </div>
+                <!-- Export Plays -->
+                <div class="action-button-container">
+                  <button type="button" class="btn btn-success action-button" id="exportPlaysButton">
+                    <i class="bi bi-download"></i>
+                    <span class="action-button-name">Export Plays</span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -1246,6 +1246,8 @@ $(document).ready(function() {
     $("#wizardEditMainForm").click(function() {
         if(wizardModalInstance) wizardModalInstance.hide();
     });
+
+    $("#exportPlaysButton").click(exportPlaysToCsv);
     
     // Tutorial and Manual buttons
     $("#helpEnglish").click(() => startTutorial('en'));
@@ -1718,6 +1720,33 @@ function resetForm() {
     selectedDaysCount = fpInstance.selectedDates.length > 0 ? fpInstance.selectedDates.length : 1;
 
     console.log("Form reset complete.");
+}
+
+function exportPlaysToCsv() {
+    const rows = $("#tablaJugadas > tr");
+    if (rows.length === 0) {
+        alert("No plays to export.");
+        return;
+    }
+
+    let csvContent = "Bet Number,Straight,Box,Combo\n";
+    rows.each(function() {
+        const bn = $(this).find(".betNumber").val() || "";
+        const straight = $(this).find(".straight").val() || "";
+        const box = $(this).find(".box").val() || "";
+        const combo = $(this).find(".combo").val() || "";
+        csvContent += `"${bn}","${straight}","${box}","${combo}"\n`;
+    });
+
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'jugadas.csv';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
 }
 
 function validateMainPlays() {


### PR DESCRIPTION
## Summary
- add Export Plays action button
- implement `exportPlaysToCsv` in scripts
- wire export function in jQuery ready handler

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_687db184e0008324b790fc384d807bfe